### PR TITLE
feat: improve layout of landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,16 +56,19 @@
 <hr class="uk-divider-icon">
 
 
-<div class="uk-card uk-card-default uk-card-body uk-width-1-2@m uk-flex uk-flex-center uk-card-hover uk-align-center">
-    <h3 class="uk-card-title" style="padding:0.7em;">Why another package manager?</h3>
+<div class="uk-card uk-card-default uk-card-body uk-width-1-2@m uk-flex uk-flex-center uk-flex-wrap uk-card-hover uk-align-center"
+     style="text-align: center;">
+    <h3 class="uk-card-title" style="text-align: center;">Why another package manager?</h3>
     <p>If you've ever used the AUR, you know that every package known to man is there. But why is this Arch specific? That's why I made Pacstall. An AUR-like alternative, for Ubuntu!</p>
 </div>
-<div class="uk-card uk-card-default uk-card-body uk-width-1-2@m uk-card-hover uk-align-center">
+<div class="uk-card uk-card-default uk-card-body uk-width-1-2@m uk-flex uk-flex-center uk-flex-wrap uk-card-hover uk-align-center"
+     style="text-align: center;">
     <h3 class="uk-card-title">How does it work then?</h3>
     <p>Pacstall takes in files known as <a href="https://github.com/pacstall/pacstall-programs/blob/master/make-a-pacscript.md">pacscripts</a> (similar to PKGBUILD's) that contain the necessary contents to build packages, and builds them into executables on your system.</p>
 </div>
-<div class="uk-card uk-card-default uk-card-body uk-width-1-2@m uk-flex uk-flex-center uk-card-hover uk-align-center">
-    <h3 class="uk-card-title" style="padding:0.7em;">Why is this any different than any other package manager?</h3>
+<div class="uk-card uk-card-default uk-card-body uk-width-1-2@m uk-flex uk-flex-center uk-flex-wrap uk-card-hover uk-align-center"
+     style="text-align: center;">
+    <h3 class="uk-card-title">Why is this any different than any other package manager?</h3>
     <p>Pacstall uses the stable base of Ubuntu but allows you to use bleeding edge software with little to no compromises, so you don't have to worry about security patches or new features.</p>
 </div>
 


### PR DESCRIPTION
- Center align all of the text in cards
- Put all of the header text on top of the paragraph text instead of
  being side-to-side
- Remove unnecessary padding

## Before
![Pacstall site before](https://user-images.githubusercontent.com/39676098/146121905-5ee0bf32-4f67-4500-8a5f-754f32c94b65.png)

## After
![Pacstall site after](https://user-images.githubusercontent.com/39676098/146121918-c487067b-df57-43f9-b4e4-c0ecf8256a15.png)