### PR TITLE
feat: load matomo only when doNotTrack allows it

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
     <head>
         <meta charset="utf-8" />

--- a/client/index.production.html
+++ b/client/index.production.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
     <head>
         <meta charset="utf-8" />
@@ -24,44 +24,52 @@
         <meta name="next-head-count" content="20" />
         <link rel="stylesheet" href="/styles/global.css" />
         <script>
-            var _paq = (window._paq = window._paq || [])
+            const IS_TRACKING_ENABLED = navigator.doNotTrack !== '1'
 
-            _paq.push(['trackPageView'])
-            _paq.push(['enableLinkTracking'])
-            ;(function () {
-                var u = '//pacstall.dev/matomo/'
-                _paq.push(['setTrackerUrl', u + 'matomo.php'])
-                _paq.push(['setSiteId', '1'])
-                var d = document,
-                    g = d.createElement('script'),
-                    s = d.getElementsByTagName('script')[0]
-                g.async = true
-                g.src = u + 'matomo.js'
-                s.parentNode.insertBefore(g, s)
-            })()
-            ;(function () {
-                var url = window.location.href
-                setInterval(function () {
-                    if (url != window.location.href) {
-                        url = window.location.href
+            if (IS_TRACKING_ENABLED) {
+                enableMatomoTracking()
+            }
 
-                        // Track page view after 0.75s to catch the title change
-                        setTimeout(function () {
-                            _paq.push([
-                                'setCustomUrl',
-                                window.location.href.split(
-                                    'https://pacstall.dev',
-                                )[1],
-                            ])
-                            _paq.push([
-                                'setDocumentTitle',
-                                window.document.title,
-                            ])
-                            _paq.push(['trackPageView'])
-                        }, 750)
-                    }
-                }, 100)
-            })()
+            function enableMatomoTracking() {
+                var _paq = (window._paq = window._paq || [])
+
+                _paq.push(['trackPageView'])
+                _paq.push(['enableLinkTracking'])
+                ;(function () {
+                    var u = '//pacstall.dev/matomo/'
+                    _paq.push(['setTrackerUrl', u + 'matomo.php'])
+                    _paq.push(['setSiteId', '1'])
+                    var d = document,
+                        g = d.createElement('script'),
+                        s = d.getElementsByTagName('script')[0]
+                    g.async = true
+                    g.src = u + 'matomo.js'
+                    s.parentNode.insertBefore(g, s)
+                })()
+                ;(function () {
+                    var url = window.location.href
+                    setInterval(function () {
+                        if (url != window.location.href) {
+                            url = window.location.href
+
+                            // Track page view after 0.75s to catch the title change
+                            setTimeout(function () {
+                                _paq.push([
+                                    'setCustomUrl',
+                                    window.location.href.split(
+                                        'https://pacstall.dev',
+                                    )[1],
+                                ])
+                                _paq.push([
+                                    'setDocumentTitle',
+                                    window.document.title,
+                                ])
+                                _paq.push(['trackPageView'])
+                            }, 750)
+                        }
+                    }, 100)
+                })()
+            }
         </script>
     </head>
 

--- a/client/index.production.html
+++ b/client/index.production.html
@@ -24,9 +24,9 @@
         <meta name="next-head-count" content="20" />
         <link rel="stylesheet" href="/styles/global.css" />
         <script>
-            const IS_TRACKING_ENABLED = navigator.doNotTrack !== '1'
+            const IS_TRACKING_ALLOWED = navigator.doNotTrack !== '1'
 
-            if (IS_TRACKING_ENABLED) {
+            if (IS_TRACKING_ALLOWED) {
                 enableMatomoTracking()
             }
 


### PR DESCRIPTION
This PR updates the code such that Matomo only gets loaded when `navigator.doNotTrack` is unset or allows it.