### PR TITLE
ref(*): fix all the things

### DIFF
--- a/client/src/components/package-details/MinimalPackageTable.tsx
+++ b/client/src/components/package-details/MinimalPackageTable.tsx
@@ -4,12 +4,13 @@ import { ArchDistroString } from '../../types/package-info'
 import MinimalPackageTableRow from './MinimalPackageTableRow'
 import { useTranslation } from 'react-i18next'
 
-const MinimalPackageTable: FC<{ packages: (ArchDistroString | string)[] }> = ({
-    packages,
-}) => {
+const MinimalPackageTable: FC<{
+    packages: (ArchDistroString | string)[]
+    type: string
+}> = ({ packages, type }) => {
     const { t } = useTranslation()
     return (
-        <Table variant={'simple'}>
+        <Table variant='simple'>
             <Thead>
                 <Tr>
                     <Th>{t('packageDetails.requiredByModal.name')}</Th>
@@ -21,9 +22,13 @@ const MinimalPackageTable: FC<{ packages: (ArchDistroString | string)[] }> = ({
             <Tbody>
                 {packages.map((pkg, i) => (
                     <MinimalPackageTableRow
-                        external={typeof pkg === 'string'}
-                        key={(typeof pkg === 'string' ? pkg : pkg.value) + i}
-                        pkg={typeof pkg === 'string' ? pkg : pkg.value}
+                        external={
+                            type !== 'requiredBy' &&
+                            type !== 'pacstallDependencies'
+                        }
+                        key={(pkg.value || pkg.packageName) + i}
+                        pkg={pkg.value || pkg.packageName}
+                        description={pkg.description || null}
                     />
                 ))}
             </Tbody>

--- a/client/src/components/package-details/MinimalPackageTableRow.tsx
+++ b/client/src/components/package-details/MinimalPackageTableRow.tsx
@@ -10,22 +10,11 @@ import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link as Rlink } from 'react-router-dom'
 
-const getDescription = (nameWithDescription: string): string | null => {
-    return nameWithDescription?.includes(':')
-        ? nameWithDescription.split(':')[1].trim()
-        : null
-}
-
-const getName = (nameWithDescription: string): string => {
-    return nameWithDescription?.includes(':')
-        ? nameWithDescription.split(':')[0]
-        : nameWithDescription
-}
-
-const MinimalPackageTableRow: FC<{ pkg: string; external: boolean }> = ({
-    pkg,
-    external,
-}) => {
+const MinimalPackageTableRow: FC<{
+    pkg: string
+    description: string
+    external: boolean
+}> = ({ pkg, description, external }) => {
     const { t } = useTranslation()
 
     return (
@@ -34,13 +23,13 @@ const MinimalPackageTableRow: FC<{ pkg: string; external: boolean }> = ({
                 <Tooltip
                     openDelay={500}
                     label={
-                        getDescription(pkg) ||
+                        description ||
                         t('packageDetails.dependenciesModal.noDescription')
                     }
                 >
                     <Text fontSize='md' fontWeight='500'>
                         {external ? (
-                            <>{getName(pkg)}</>
+                            <>{pkg}</>
                         ) : (
                             <Link
                                 as={Rlink}
@@ -49,9 +38,9 @@ const MinimalPackageTableRow: FC<{ pkg: string; external: boolean }> = ({
                                     'pink.600',
                                     'pink.400',
                                 )}
-                                to={`/packages/${getName(pkg)}`}
+                                to={`/packages/${pkg}`}
                             >
-                                {getName(pkg)}
+                                {pkg}
                             </Link>
                         )}
                     </Text>

--- a/client/src/components/package-details/PackageDependenciesModal.tsx
+++ b/client/src/components/package-details/PackageDependenciesModal.tsx
@@ -51,6 +51,7 @@ const PackageDependenciesModal: FC<{ name: string } & UseDisclosureProps> = ({
                                         packages={
                                             data!.runtimeDependencies || []
                                         }
+                                        type='runtimeDependencies'
                                     />
                                 </Box>
                             )}
@@ -64,6 +65,7 @@ const PackageDependenciesModal: FC<{ name: string } & UseDisclosureProps> = ({
                                     </Heading>
                                     <MinimalPackageTable
                                         packages={data!.buildDependencies || []}
+                                        type='buildDependencies'
                                     />
                                 </Box>
                             )}
@@ -79,6 +81,7 @@ const PackageDependenciesModal: FC<{ name: string } & UseDisclosureProps> = ({
                                         packages={
                                             data!.optionalDependencies || []
                                         }
+                                        type='optionalDependencies'
                                     />
                                 </Box>
                             )}
@@ -94,6 +97,7 @@ const PackageDependenciesModal: FC<{ name: string } & UseDisclosureProps> = ({
                                         packages={
                                             data!.pacstallDependencies || []
                                         }
+                                        type='pacstallDependencies'
                                     />
                                 </Box>
                             )}

--- a/client/src/components/package-details/PackageDetailsHeader.tsx
+++ b/client/src/components/package-details/PackageDetailsHeader.tsx
@@ -1,7 +1,6 @@
 import { HStack, Heading, Text } from '@chakra-ui/react'
 import { FC } from 'react'
 import PackageInfo from '../../types/package-info'
-import InstallNowButton from './InstallNowButton'
 
 const PackageDetailsHeader: FC<{ data: PackageInfo; isMobile: boolean }> = (
     { data },
@@ -13,7 +12,6 @@ const PackageDetailsHeader: FC<{ data: PackageInfo; isMobile: boolean }> = (
                 <HStack>
                     <Heading>{data.packageName}</Heading>
                 </HStack>
-                {!isMobile && <InstallNowButton />}
             </HStack>
 
             <Text mt='5'>{data.description}</Text>

--- a/client/src/components/package-details/PackageDetailsPage.tsx
+++ b/client/src/components/package-details/PackageDetailsPage.tsx
@@ -52,7 +52,13 @@ const PackageDetailsPage: FC<PackageDetailsPageProps> = ({
                 requiredByModal={requiredByModal}
             />
             <HowToInstall
-                name={data.packageName}
+                name={
+                    data.baseTotal > 1
+                        ? data.baseIndex === 0
+                            ? `${data.packageBase}:pkgbase`
+                            : `${data.packageBase}:${data.packageName}`
+                        : data.packageName
+                }
                 prettyName={data.packageName}
                 isMobile={isMobile}
             />

--- a/client/src/components/package-details/PackageDetailsTable.tsx
+++ b/client/src/components/package-details/PackageDetailsTable.tsx
@@ -114,7 +114,7 @@ const PackageDetailsTable: FC<{
                     <Link
                         color='pink.400'
                         isExternal
-                        href={`https://github.com/pacstall/pacstall-programs/blob/master/packages/${data.packageName}/${data.packageName}.pacscript`}
+                        href={`https://github.com/pacstall/pacstall-programs/blob/master/packages/${data.packageBase}/${data.packageBase}.pacscript`}
                     >
                         {t('packageDetails.openInGithub')}{' '}
                         <Icon

--- a/client/src/components/package-details/PackageRequiredByModal.tsx
+++ b/client/src/components/package-details/PackageRequiredByModal.tsx
@@ -23,7 +23,9 @@ const PackageRequiredByModal: FC<{ name: string } & UseDisclosureProps> = ({
     const { data, loading, error } = usePackageRequiredBy(name)
     const { t } = useTranslation()
 
-    const ComputedPackageList = () => <MinimalPackageTable packages={data} />
+    const ComputedPackageList = () => (
+        <MinimalPackageTable packages={data} type='requiredBy' />
+    )
 
     return (
         <Modal scrollBehavior='inside' isOpen={isOpen!} onClose={onClose!}>

--- a/client/src/components/packages/PackageTableRow.tsx
+++ b/client/src/components/packages/PackageTableRow.tsx
@@ -90,7 +90,16 @@ const PackageTableRow: FC<{ pkg: PackageInfo; disabled?: boolean }> = ({
                 display={useBreakpointValue({ base: 'none', md: 'table-cell' })}
             >
                 <Text fontSize='sm'>
-                    <SmartCodeSnippetInstall size='sm' name={pkg.packageName} />
+                    <SmartCodeSnippetInstall
+                        size='sm'
+                        name={
+                            pkg.baseTotal > 1
+                                ? pkg.baseIndex === 0
+                                    ? `${pkg.packageBase}:pkgbase`
+                                    : `${pkg.packageBase}:${pkg.packageName}`
+                                : pkg.packageName
+                        }
+                    />
                 </Text>
             </Td>
         </Tr>

--- a/client/src/types/package-info.ts
+++ b/client/src/types/package-info.ts
@@ -1,8 +1,12 @@
 export default interface PackageInfo {
     packageName: string
     prettyName: string
+    packageBase: string
+    baseIndex: int
+    baseTotal: int
     description: string
     version: string
+    sourceVersion: string
     release: string
     epoch: string
     latestVersion?: string

--- a/server/types/pac/parser/last_updated.go
+++ b/server/types/pac/parser/last_updated.go
@@ -85,7 +85,7 @@ func setLastUpdatedAt(packages []*pac.Script) error {
 
 	for _, pkg := range packages {
 		if tuple, err := array.FindBy(lastUpdatedTuples, func(tuple packageLastUpdatedTuple) bool {
-			return tuple.packageName == pkg.PackageName
+			return tuple.packageName == pkg.PackageBase
 		}); err == nil {
 			pkg.LastUpdatedAt = tuple.lastUpdated
 		} else {

--- a/server/types/pac/parser/pacsh/git_version.go
+++ b/server/types/pac/parser/pacsh/git_version.go
@@ -18,8 +18,10 @@ func ApplyGitVersion(p *pac.Script) error {
 	}
 
 	if p.Epoch != "" {
+		p.SourceVersion = version
 		p.Version = p.Epoch + ":" + version + "-" + p.Release
 	} else {
+		p.SourceVersion = version
 		p.Version = version + "-" + p.Release
 	}
 

--- a/server/types/pac/parser/pacsh/parse_pac_output.go
+++ b/server/types/pac/parser/pacsh/parse_pac_output.go
@@ -5,15 +5,17 @@ import (
 	"pacstall.dev/webserver/types/pac"
 )
 
-func ParsePacOutput(data []byte) (*pac.Script, error) {
+func ParsePacOutput(data []byte) ([]*pac.Script, error) {
+	var scripts []*pac.Script
 	out, err := srcinfo.Parse(string(data))
 	if err != nil {
 		return nil, err
 	}
 
-	ps := pac.FromSrcInfo(*out)
+	scripts = pac.FromSrcInfo(*out)
+	for idx := range scripts {
+        scripts[idx].PrettyName = getPrettyName(scripts[idx])
+    }
 
-	ps.PrettyName = getPrettyName(ps)
-
-	return ps, nil
+	return scripts, nil
 }

--- a/server/types/pac/parser/search.go
+++ b/server/types/pac/parser/search.go
@@ -37,6 +37,7 @@ func FilterPackages(packages []*pac.Script, filter, filterBy string) []*pac.Scri
 	case "name":
 		return filterByFunc(func(pi *pac.Script) bool {
 			return strings.Contains(pi.PackageName, filter) ||
+				strings.Contains(pi.PackageBase, filter) ||
 				func(ps []pac.ArchDistroString, filter string) bool {
 					return array.Any(ps, func(it pac.ArchDistroString) bool {
 						return strings.Contains(it.Value, filter)


### PR DESCRIPTION
Fixes the following issues:
- Removes the `Install Now` button that does nothing
- `requiredBy` programs now show up again in their modal
- Dependencies now correctly show their provider again
- Both `requiredBy` and `pacstallDependencies` now correctly show their description in the tooltip on hover
- Split packages are now correctly parsed
- New API access vars:
    - `PackageBase`/`packageBase`: the `pkgbase` of the package
    - `BaseIndex`/`baseIndex`: the index of a package within a `pkgbase`
    - `BaseTotal`/`baseTotal`: the total number of packages built by a `pkgbase`
    - `SourceVersion`/`sourceVersion`: the direct `pkgver` var, split from `epoch` and `pkgrel`