### PR TITLE
fix(parser): ensure equiv empty types for `repology`

### DIFF
--- a/server/types/pac/script.go
+++ b/server/types/pac/script.go
@@ -151,7 +151,7 @@ func FromSrcInfo(info srcinfo.Srcinfo) []*Script {
 			Sha384Sums:           toArchDistroStrings(info.SHA384Sums),
 			Sha512Sums:           toArchDistroStrings(info.SHA512Sums),
 			Backup:               orEmptyArray(info.Backup),
-			Repology:             info.Repology,
+			Repology:             orEmptyArray(info.Repology),
 			RequiredBy:           []string{},
 			UpdateStatus:         UpdateStatus.Unknown,
 		})


### PR DESCRIPTION
Not urgent but bothersome

<img width="596" alt="Screenshot 2025-01-16 at 12 42 17 AM" src="https://github.com/user-attachments/assets/b7d863ac-3715-4cb7-8892-282f8e9ab2b6" />


`pkgbase` parent returns null when it should return empty array like everyone else