### PR TITLE
fix(api): programs-based files

### DIFF
--- a/server/server/api/repology/types.go
+++ b/server/server/api/repology/types.go
@@ -30,7 +30,7 @@ func newRepologyPackage(p *pac.Script) repologyPackage {
 		VisibleName:       p.PrettyName,
 		Description:       p.Description,
 		Maintainer:        getMaintainers(p),
-		Version:           p.Version,
+		Version:           p.SourceVersion,
 		URL:               p.Source,
 		Type:              string(p.Type()),
 		RecipeURL:         fmt.Sprintf("https://raw.githubusercontent.com/pacstall/pacstall-programs/master/packages/%s/%s.pacscript", p.PackageBase, p.PackageBase),

--- a/server/types/pac/script.go
+++ b/server/types/pac/script.go
@@ -1,6 +1,7 @@
 package pac
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
@@ -148,7 +149,7 @@ func FromSrcInfo(info srcinfo.Srcinfo) []*Script {
 			Compatible:           orEmptyArray(info.Compatible),
 			Incompatible:         orEmptyArray(info.Incompatible),
 			Maintainers:          info.Maintainer,
-			Source:               toSourceStrings(info.Source),
+			Source:               toSourceStrings(info.Pkgbase, info.Source),
 			NoExtract:            orEmptyArray(info.NoExtract),
 			NoSubmodules:         orEmptyArray(info.NoSubmodules),
 			Md5Sums:              toArchDistroStrings(info.MD5Sums),
@@ -200,7 +201,7 @@ func FromSrcInfo(info srcinfo.Srcinfo) []*Script {
 			Compatible:           orEmptyArray(info.Compatible),
 			Incompatible:         orEmptyArray(info.Incompatible),
 			Maintainers:          info.Maintainer,
-			Source:               toSourceStrings(info.Source),
+			Source:               toSourceStrings(info.Pkgbase, info.Source),
 			NoExtract:            orEmptyArray(info.NoExtract),
 			NoSubmodules:         orEmptyArray(info.NoSubmodules),
 			Md5Sums:              toArchDistroStrings(info.MD5Sums),
@@ -259,9 +260,12 @@ func toArchDistroString(ads srcinfo.ArchDistroString) ArchDistroString {
 	}
 }
 
-func toSourceStrings(ads []srcinfo.ArchDistroString) []ArchDistroString {
+func toSourceStrings(pkgbase string, ads []srcinfo.ArchDistroString) []ArchDistroString {
 	return array.SwitchMap(ads, func(it *array.Iterator[srcinfo.ArchDistroString]) ArchDistroString {
 		source, dest := extractSource(it.Value.Value)
+		if !strings.Contains(source, "://") {
+			source = fmt.Sprintf("https://raw.githubusercontent.com/pacstall/pacstall-programs/master/packages/%s/%s", pkgbase, source)
+		}
 		return ArchDistroString{
 			Arch:   it.Value.Arch,
 			Distro: it.Value.Distro,


### PR DESCRIPTION
Ensures files hosted in `pacstall-programs` (which are listed without any URI prefix) are linked properly. Example:

before:
```
    {
      "arch": "arm64",
      "value": "firefox-developer-edition.desktop"
    },
```

after:
```
    {
      "arch": "arm64",
      "value": "https://raw.githubusercontent.com/pacstall/pacstall-programs/master/packages/firefox-developer-edition-bin/firefox-developer-edition.desktop"
    },
```

need for providing repology with accurate data